### PR TITLE
Experiment with beautify

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,0 +1,15 @@
+indent_with_tabs=2
+input_tab_size=2
+output_tab_size=2
+indent_columns=output_tab_size
+indent_class=true
+indent_namespace=false
+indent_extern=true
+
+nl_func_leave_one_liners=true
+
+sp_angle_shift=remove
+sp_permit_cpp11_shift=true
+
+sp_after_semi_for=ignore
+sp_before_semi_for=ignore

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -4,13 +4,15 @@
 
 # note: with the -style=file option, clang-format reads the config from ./.clang-format
 # See here for the full list of supported options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-FORMAT_CMD="clang-format -i -style=file"
+FORMAT_CMD_CLANG_FORMAT="clang-format -i -style=file"
+FORMAT_CMD_UNCRUSTIFY="uncrustify -c .uncrustify.cfg --no-backup"
+FORMAT_CMD=$FORMAT_CMD_CLANG_FORMAT
 
 # Filter out any files that shouldn't be auto-formatted.
 # note: -v flag inverts selection - this tells grep to *filter out* anything
 #       that matches the pattern. For testing, you can remove the -v to ssee
 #       which files would have been excluded.
-FILTER_CMD="grep -v -E objects|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
+FILTER_CMD="grep -v -E objects|src/libsvg|src/libtess2|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
 
 function reformat_all() {
     find src -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \
@@ -32,7 +34,10 @@ function reformat_changed() {
 }
 
 # main
-if [[ "$#" -eq 1 && "$1" == "--all" ]]; then
+if [ "`echo $* | grep uncrust`" ]; then
+    FORMAT_CMD=$FORMAT_CMD_UNCRUSTIFY
+fi
+if [ "`echo $* | grep -- --all`" ]; then
     echo "Reformatting all files..."
     reformat_all
 else


### PR DESCRIPTION
This disables most uncrustify settings, resulting in a "minimal" patch:
`./scripts/beautify.sh --all --uncrust`

My hope would be that this can enable us to gradually introduce style checks until the whole codebase conforms to a checked style.
After that, we could do larger changes like switching to space indenting or deciding on general updates to coding style.
